### PR TITLE
Do not hardcode gptel model

### DIFF
--- a/sources/consult-web-chatgpt.el
+++ b/sources/consult-web-chatgpt.el
@@ -54,7 +54,7 @@ See URL `https://openai.com/product' and URL `https://platform.openai.com/docs/i
 
 (cl-defun consult-web--chatgpt-fetch-results (input &rest args &key model &allow-other-keys)
   "Fetches chat response for INPUT from chatGPT."
-  (let* ((model (or model "gpt-3.5-turbo"))
+  (let* ((model (or model gptel-model))
          (headers `(("Content-Type" . "application/json")
                     ("Authorization" . ,(concat "Bearer " (consult-web-expand-variable-function consult-web-openai-api-key))))))
     (funcall consult-web-retrieve-backend


### PR DESCRIPTION
Currently, when no model parameter is passed to `consult-web--chatgpt-fetch-results`, `"gpt-3.5-turbo"` is used. This pull request makes the function instead use the value of `gptel-model`, allowing the user to set the model to whichever one they have set in  their `gptel` configuration.